### PR TITLE
Add calculation tests

### DIFF
--- a/subject_to_analyzer.py
+++ b/subject_to_analyzer.py
@@ -1,67 +1,81 @@
+import os
 import streamlit as st
 import pandas as pd
 import numpy as np
 import numpy_financial as nf
 import altair as alt
 
-st.set_page_config(page_title="Real Estate Deal Analyzer v8", layout="wide")
-st.title("🏠 Real Estate Deal Analyzer – Net-Sheet Edition (v8)")
-
-# --- 1. Global Assumptions -----------------------------------------
-with st.sidebar:
-    st.header("Global Assumptions")
-    market_rent   = st.number_input("Market Rent ($/mo)",  0.0, 1e6, 2000.0, 50.0)
-    rent_growth   = st.slider("Annual Rent Growth %", 0.00, 0.10, 0.02, 0.005)  # new rent growth assumption ($/mo)",  0.0, 1e6, 2000.0, 50.0)
-    expense_ratio = st.slider("Operating Expense Ratio", 0.00, 1.00, 0.35, 0.01)
-    market_rate   = st.slider("Market Mortgage Rate",    0.01, 0.10, 0.05, 0.001)
-    market_term   = st.slider("Mortgage Term (yrs)",    10,   30,   30)
-    closing_pct   = st.slider("Closing Cost % (buy & sell)", 0.00, 0.10, 0.06, 0.005)
-    show_debug    = st.checkbox("Show Debug Data in Net-Sheet", value=False)
-
-oper_exp = market_rent * expense_ratio  # monthly operating expenses
-
-# --- 2. Deal Inputs ------------------------------------------------
-DEAL_TYPES = ["Subject-To","Conventional","Seller Financing","BRRRR"]
-num_deals = st.sidebar.number_input("# Deals to Compare", 1, 4, 2)
-
+# Defaults allow importing this module without executing the Streamlit UI.
+market_rent = 0.0
+rent_growth = 0.0
+expense_ratio = 0.0
+market_rate = 0.0
+market_term = 0
+closing_pct = 0.0
+show_debug = False
+oper_exp = 0.0
+DEAL_TYPES = ["Subject-To", "Conventional", "Seller Financing", "BRRRR"]
 deal_configs = []
-for i in range(int(num_deals)):
+
+if not os.environ.get("DEAL_ANALYZER_SKIP_UI"):
+    st.set_page_config(page_title="Real Estate Deal Analyzer v8", layout="wide")
+    st.title("🏠 Real Estate Deal Analyzer – Net-Sheet Edition (v8)")
+
+    # --- 1. Global Assumptions -----------------------------------------
     with st.sidebar:
-        st.markdown("---")
-        name  = st.text_input(f"Deal {i+1} Name", value=f"Deal {i+1}", key=f"name{i}")
-        dtype = st.selectbox("Type", DEAL_TYPES, key=f"type{i}")
-        pp    = st.number_input("Purchase Price", 0.0, 1e7, 300000.0, 10000.0, key=f"pp{i}")
-        hold  = st.slider("Holding Period (yrs)", 1, 30, 10, key=f"hold{i}")
-        gr    = st.slider("Annual Appreciation %", 0.00, 0.10, 0.04, 0.005, key=f"gr{i}")
-        dr    = st.slider("Discount Rate %", 0.00, 0.20, 0.08, 0.005, key=f"dr{i}")
-        params = {"name": name, "type": dtype, "pp": pp, "hold": hold, "gr": gr, "dr": dr}
-        if dtype == "Subject-To":
-            params.update({
-                "eb":      st.number_input("Existing Loan Balance", 0.0, pp, 200000.0, 10000.0, key=f"eb{i}"),
-                "rate":    st.slider("Subject Loan Rate", 0.01, 0.08, 0.035, 0.001, key=f"sr{i}"),
-                "term":    st.slider("Loan Term Remaining (yrs)", 1, 30, 25, key=f"tr{i}"),
-                "premium": st.number_input("Premium to Seller", 0.0, 1e6, 10000.0, 1000.0, key=f"prem{i}")
-            })
-        elif dtype == "Conventional":
-            params.update({
-                "dp_pct": st.slider("Down Payment %", 0.05, 0.50, 0.20, 0.01, key=f"dp{i}"),
-                "rate":   st.slider("Mortgage Rate",   0.02, 0.10, 0.05, 0.001, key=f"cr{i}"),
-                "term":   st.slider("Loan Term (yrs)", 10, 30, 30, key=f"ct{i}")
-            })
-        elif dtype == "Seller Financing":
-            params.update({
-                "fin_pct": st.slider("Seller-Financed %", 0.00, 1.00, 0.80, 0.01, key=f"fp{i}"),
-                "rate":    st.slider("Note Rate",     0.01, 0.10, 0.06, 0.001, key=f"nr{i}"),
-                "term":    st.slider("Note Term (yrs)", 1, 30, 5, key=f"nt{i}")
-            })
-        else:  # BRRRR
-            params.update({
-                "rehab": st.number_input("Rehab Cost", 0.0, 1e6, 50000.0, 5000.0, key=f"rc{i}"),
-                "arv":   st.number_input("After-Repair Value", 0.0, 1e7, 350000.0, 10000.0, key=f"arv{i}"),
-                "rr":    st.slider("Refi Rate",    0.02, 0.10, 0.05, 0.001, key=f"rr{i}"),
-                "rlv":   st.slider("Refi LTV",    0.50, 0.80, 0.75, 0.01, key=f"rl{i}")
-            })
-        deal_configs.append(params)
+        st.header("Global Assumptions")
+        market_rent = st.number_input("Market Rent ($/mo)", 0.0, 1e6, 2000.0, 50.0)
+        rent_growth = st.slider("Annual Rent Growth %", 0.00, 0.10, 0.02, 0.005)
+        expense_ratio = st.slider("Operating Expense Ratio", 0.00, 1.00, 0.35, 0.01)
+        market_rate = st.slider("Market Mortgage Rate", 0.01, 0.10, 0.05, 0.001)
+        market_term = st.slider("Mortgage Term (yrs)", 10, 30, 30)
+        closing_pct = st.slider("Closing Cost % (buy & sell)", 0.00, 0.10, 0.06, 0.005)
+        show_debug = st.checkbox("Show Debug Data in Net-Sheet", value=False)
+
+    oper_exp = market_rent * expense_ratio  # monthly operating expenses
+
+    # --- 2. Deal Inputs ------------------------------------------------
+    num_deals = st.sidebar.number_input("# Deals to Compare", 1, 4, 2)
+
+    deal_configs = []
+    for i in range(int(num_deals)):
+        with st.sidebar:
+            st.markdown("---")
+            name = st.text_input(f"Deal {i+1} Name", value=f"Deal {i+1}", key=f"name{i}")
+            dtype = st.selectbox("Type", DEAL_TYPES, key=f"type{i}")
+            pp = st.number_input("Purchase Price", 0.0, 1e7, 300000.0, 10000.0, key=f"pp{i}")
+            hold = st.slider("Holding Period (yrs)", 1, 30, 10, key=f"hold{i}")
+            gr = st.slider("Annual Appreciation %", 0.00, 0.10, 0.04, 0.005, key=f"gr{i}")
+            dr = st.slider("Discount Rate %", 0.00, 0.20, 0.08, 0.005, key=f"dr{i}")
+            params = {"name": name, "type": dtype, "pp": pp, "hold": hold, "gr": gr, "dr": dr}
+            if dtype == "Subject-To":
+                params.update({
+                    "eb": st.number_input("Existing Loan Balance", 0.0, pp, 200000.0, 10000.0, key=f"eb{i}"),
+                    "rate": st.slider("Subject Loan Rate", 0.01, 0.08, 0.035, 0.001, key=f"sr{i}"),
+                    "term": st.slider("Loan Term Remaining (yrs)", 1, 30, 25, key=f"tr{i}"),
+                    "premium": st.number_input("Premium to Seller", 0.0, 1e6, 10000.0, 1000.0, key=f"prem{i}")
+                })
+            elif dtype == "Conventional":
+                params.update({
+                    "dp_pct": st.slider("Down Payment %", 0.05, 0.50, 0.20, 0.01, key=f"dp{i}"),
+                    "rate": st.slider("Mortgage Rate", 0.02, 0.10, 0.05, 0.001, key=f"cr{i}"),
+                    "term": st.slider("Loan Term (yrs)", 10, 30, 30, key=f"ct{i}")
+                })
+            elif dtype == "Seller Financing":
+                params.update({
+                    "fin_pct": st.slider("Seller-Financed %", 0.00, 1.00, 0.80, 0.01, key=f"fp{i}"),
+                    "rate": st.slider("Note Rate", 0.01, 0.10, 0.06, 0.001, key=f"nr{i}"),
+                    "term": st.slider("Note Term (yrs)", 1, 30, 5, key=f"nt{i}")
+                })
+            else:  # BRRRR
+                params.update({
+                    "rehab": st.number_input("Rehab Cost", 0.0, 1e6, 50000.0, 5000.0, key=f"rc{i}"),
+                    "arv": st.number_input("After-Repair Value", 0.0, 1e7, 350000.0, 10000.0, key=f"arv{i}"),
+                    "rr": st.slider("Refi Rate", 0.02, 0.10, 0.05, 0.001, key=f"rr{i}"),
+                    "rlv": st.slider("Refi LTV", 0.50, 0.80, 0.75, 0.01, key=f"rl{i}")
+                })
+            deal_configs.append(params)
+
 
 # --- 3. Helpers -----------------------------------------------------
 def amortize(balance, rate_mo, payment, periods):
@@ -221,68 +235,69 @@ def brrrr_cf(p):
     }
     return cf, sheet
 
-# --- 5. Side-by-Side Deal Cards with Inline Net-Sheets -----------
-cols = st.columns(int(num_deals))
-for col, cfg in zip(cols, deal_configs):
-    cf, sheet = build_cashflow_and_sheet(cfg)
-    initial_equity = sheet["Initial Equity"]
-    irr, total_roi = build_metrics(initial_equity, cf)
-    df_cf = pd.DataFrame({"Month": list(range(len(cf))), "Cash Flow ($)": cf})
-    with col:
-        st.subheader(cfg['name'])
-        st.metric("IRR", f"{irr:.2%}")
-        st.metric("Total ROI", f"{total_roi:.2%}")
-        # (Monthly cash flow chart removed)
-        with st.expander("Net-Sheet Details", expanded=False):
-            if show_debug:
-                st.json(sheet)
-            df_sheet = pd.DataFrame(sheet.items(), columns=["Line Item","Amount"]).set_index("Line Item")
-            # Format numeric amounts, leave strings intact
-            st.table(
-                df_sheet.style.format(lambda v: f"${v:,.0f}" if isinstance(v, (int, float)) else v)
-            )
+if not os.environ.get("DEAL_ANALYZER_SKIP_UI"):
+    # --- 5. Side-by-Side Deal Cards with Inline Net-Sheets -----------
+    cols = st.columns(int(num_deals))
+    for col, cfg in zip(cols, deal_configs):
+        cf, sheet = build_cashflow_and_sheet(cfg)
+        initial_equity = sheet["Initial Equity"]
+        irr, total_roi = build_metrics(initial_equity, cf)
+        df_cf = pd.DataFrame({"Month": list(range(len(cf))), "Cash Flow ($)": cf})
+        with col:
+            st.subheader(cfg['name'])
+            st.metric("IRR", f"{irr:.2%}")
+            st.metric("Total ROI", f"{total_roi:.2%}")
+            # (Monthly cash flow chart removed)
+            with st.expander("Net-Sheet Details", expanded=False):
+                if show_debug:
+                    st.json(sheet)
+                df_sheet = pd.DataFrame(sheet.items(), columns=["Line Item","Amount"]).set_index("Line Item")
+                # Format numeric amounts, leave strings intact
+                st.table(
+                    df_sheet.style.format(lambda v: f"${v:,.0f}" if isinstance(v, (int, float)) else v)
+                )
 
-# --- 6. Cumulative Cash Flow Comparison ---------------------------
-st.header("📈 Cumulative Cash Flow Comparison")
-# Build cumulative DataFrame for each deal
-cum_df = pd.DataFrame()
-for cfg in deal_configs:
-    cf, _ = build_cashflow_and_sheet(cfg)
-    cum_series = pd.Series(np.cumsum(cf), name=cfg['name'])
-    cum_df = pd.concat([cum_df, cum_series], axis=1)
+    # --- 6. Cumulative Cash Flow Comparison ---------------------------
+    st.header("📈 Cumulative Cash Flow Comparison")
+    # Build cumulative DataFrame for each deal
+    cum_df = pd.DataFrame()
+    for cfg in deal_configs:
+        cf, _ = build_cashflow_and_sheet(cfg)
+        cum_series = pd.Series(np.cumsum(cf), name=cfg['name'])
+        cum_df = pd.concat([cum_df, cum_series], axis=1)
 
-# Prepare data for Altair
-cum_df = cum_df.reset_index().rename(columns={'index': 'Month'})
-melt_df = cum_df.melt(id_vars=['Month'], var_name='Deal', value_name='Cumulative CF')
+    # Prepare data for Altair
+    cum_df = cum_df.reset_index().rename(columns={'index': 'Month'})
+    melt_df = cum_df.melt(id_vars=['Month'], var_name='Deal', value_name='Cumulative CF')
 
-# Base line chart
-base = alt.Chart(melt_df).mark_line(point=True).encode(
-    x=alt.X('Month:Q', title='Month'),
-    y=alt.Y('Cumulative CF:Q', title='Cumulative Cash Flow ($)'),
-    color='Deal:N',
-    tooltip=['Deal','Month','Cumulative CF']
-).properties(width='container', height=300)
+    # Base line chart
+    base = alt.Chart(melt_df).mark_line(point=True).encode(
+        x=alt.X('Month:Q', title='Month'),
+        y=alt.Y('Cumulative CF:Q', title='Cumulative Cash Flow ($)'),
+        color='Deal:N',
+        tooltip=['Deal','Month','Cumulative CF']
+    ).properties(width='container', height=300)
 
-# Build label data: end of rent (pre-sale) and sale points
-labels = []
-for cfg in deal_configs:
-    name = cfg['name']
-    hold_mo = cfg['hold'] * 12
-    # end of rental period (month before sale)
-    end_rent_month = hold_mo - 2
-    sale_month = hold_mo - 1
-    val_rent = cum_df.loc[cum_df['Month'] == end_rent_month, name].iloc[0]
-    val_sale = cum_df.loc[cum_df['Month'] == sale_month, name].iloc[0]
-    labels.append({'Deal': name, 'Month': end_rent_month, 'Cumulative CF': val_rent, 'Label': 'End Rent'})
-    labels.append({'Deal': name, 'Month': sale_month,      'Cumulative CF': val_sale, 'Label': 'With Sale'})
-labels_df = pd.DataFrame(labels)
+    # Build label data: end of rent (pre-sale) and sale points
+    labels = []
+    for cfg in deal_configs:
+        name = cfg['name']
+        hold_mo = cfg['hold'] * 12
+        # end of rental period (month before sale)
+        end_rent_month = hold_mo - 2
+        sale_month = hold_mo - 1
+        val_rent = cum_df.loc[cum_df['Month'] == end_rent_month, name].iloc[0]
+        val_sale = cum_df.loc[cum_df['Month'] == sale_month, name].iloc[0]
+        labels.append({'Deal': name, 'Month': end_rent_month, 'Cumulative CF': val_rent, 'Label': 'End Rent'})
+        labels.append({'Deal': name, 'Month': sale_month,      'Cumulative CF': val_sale, 'Label': 'With Sale'})
+    labels_df = pd.DataFrame(labels)
 
-text = alt.Chart(labels_df).mark_text(dx=5, dy=-5).encode(
-    x='Month:Q',
-    y='Cumulative CF:Q',
-    text='Label:N',
-    color='Deal:N'
-)
+    text = alt.Chart(labels_df).mark_text(dx=5, dy=-5).encode(
+        x='Month:Q',
+        y='Cumulative CF:Q',
+        text='Label:N',
+        color='Deal:N'
+    )
 
-# Render combined chart
-st.altair_chart(base + text, use_container_width=True)
+    # Render combined chart
+    st.altair_chart(base + text, use_container_width=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,129 @@
+import os
+import numpy as np
+import numpy_financial as nf
+import sys
+import importlib.util
+
+os.environ['DEAL_ANALYZER_SKIP_UI'] = '1'
+spec = importlib.util.spec_from_file_location("subject_to_analyzer", os.path.join(os.path.dirname(__file__), "..", "subject_to_analyzer.py"))
+sta = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = sta
+spec.loader.exec_module(sta)
+
+# Helper to recompute expected subject-to cash flows
+
+def expected_subject_cf(p):
+    mrate = p['rate']/12
+    periods = p['term']*12
+    payment = nf.pmt(mrate, periods, -p['eb'])
+    bal = p['eb']
+    cf = []
+    for m in range(1, p['hold']*12+1):
+        year = (m-1)//12
+        rent = sta.market_rent * (1 + sta.rent_growth)**year
+        exp = sta.oper_exp * (1 + sta.rent_growth)**year
+        interest = bal*mrate
+        principal = payment - interest
+        bal -= principal
+        cf.append(rent - exp - payment)
+    sale_price = p['pp']*(1+p['gr'])**p['hold']
+    sale_net = sale_price - sale_price*sta.closing_pct - bal
+    cf[-1] += sale_net
+    return cf, payment, bal
+
+def test_subject_cf_calculations():
+    sta.market_rent = 1000
+    sta.rent_growth = 0.0
+    sta.expense_ratio = 0.5
+    sta.oper_exp = sta.market_rent * sta.expense_ratio
+    sta.closing_pct = 0.05
+
+    params = {
+        'pp': 150000,
+        'eb': 100000,
+        'rate': 0.06,
+        'term': 30,
+        'premium': 10000,
+        'hold': 1,
+        'gr': 0.0,
+        'type': 'Subject-To'
+    }
+    cf, sheet = sta.subject_cf(params)
+    exp_cf, payment, bal = expected_subject_cf(params)
+    assert np.allclose(cf, exp_cf)
+    assert np.isclose(sheet['Debt Service (mo)'], payment)
+    assert np.isclose(sheet['Net Sale Proceeds'], exp_cf[-1] - (sta.market_rent - sta.oper_exp - payment))
+
+def test_conventional_cf_basic():
+    sta.market_rent = 1200
+    sta.rent_growth = 0
+    sta.expense_ratio = 0.3
+    sta.oper_exp = sta.market_rent * sta.expense_ratio
+    sta.closing_pct = 0.04
+
+    params = {
+        'pp': 200000,
+        'dp_pct': 0.2,
+        'rate': 0.05,
+        'term': 30,
+        'hold': 1,
+        'gr': 0.0,
+        'type': 'Conventional'
+    }
+    cf, sheet = sta.conventional_cf(params)
+    payment = nf.pmt(0.05/12, 30*12, -(200000*0.8))
+    assert np.isclose(sheet['Debt Service (mo)'], payment)
+    assert len(cf) == 12
+
+
+def test_seller_fin_cf_basic():
+    sta.market_rent = 1500
+    sta.rent_growth = 0
+    sta.expense_ratio = 0.4
+    sta.oper_exp = sta.market_rent * sta.expense_ratio
+    sta.closing_pct = 0.03
+
+    params = {
+        'pp': 250000,
+        'fin_pct': 0.8,
+        'rate': 0.07,
+        'term': 5,
+        'hold': 1,
+        'gr': 0.0,
+        'type': 'Seller Financing'
+    }
+    cf, sheet = sta.seller_fin_cf(params)
+    payment = nf.pmt(0.07/12, 5*12, -(250000*0.8))
+    assert np.isclose(sheet['Debt Service (mo)'], payment)
+    assert len(cf) == 12
+
+
+def test_brrrr_cf_basic():
+    sta.market_rent = 900
+    sta.rent_growth = 0
+    sta.expense_ratio = 0.45
+    sta.oper_exp = sta.market_rent * sta.expense_ratio
+    sta.closing_pct = 0.05
+
+    params = {
+        'pp': 80000,
+        'rehab': 20000,
+        'arv': 120000,
+        'rr': 0.05,
+        'rlv': 0.75,
+        'hold': 1,
+        'gr': 0.0,
+        'type': 'BRRRR'
+    }
+    cf, sheet = sta.brrrr_cf(params)
+    payment = nf.pmt(0.05/12, 12, -(120000*0.75))
+    assert np.isclose(sheet['Debt Service (mo)'], payment)
+    assert len(cf) == 12
+
+
+def test_build_metrics():
+    irr, roi = sta.build_metrics(10000, [2000]*5)
+    expected_irr = nf.irr([-10000] + [2000]*5)
+    expected_roi = (2000*5)/10000
+    assert np.isclose(irr, expected_irr)
+    assert np.isclose(roi, expected_roi)


### PR DESCRIPTION
## Summary
- make `subject_to_analyzer` importable by guarding Streamlit UI with an env var
- add a regression test suite for the deal models and metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c97d09658832bbb4792a978fda09c