### PR TITLE
Fix metrics annualization and add tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 pandas
 numpy
 numpy-financial
+altair

--- a/subject_to_analyzer.py
+++ b/subject_to_analyzer.py
@@ -11,7 +11,7 @@ st.title("🏠 Real Estate Deal Analyzer – Net-Sheet Edition (v8)")
 with st.sidebar:
     st.header("Global Assumptions")
     market_rent   = st.number_input("Market Rent ($/mo)",  0.0, 1e6, 2000.0, 50.0)
-    rent_growth   = st.slider("Annual Rent Growth %", 0.00, 0.10, 0.02, 0.005)  # new rent growth assumption ($/mo)",  0.0, 1e6, 2000.0, 50.0)
+    rent_growth   = st.slider("Annual Rent Growth %", 0.00, 0.10, 0.02, 0.005)  # annual rent growth percentage
     expense_ratio = st.slider("Operating Expense Ratio", 0.00, 1.00, 0.35, 0.01)
     market_rate   = st.slider("Market Mortgage Rate",    0.01, 0.10, 0.05, 0.001)
     market_term   = st.slider("Mortgage Term (yrs)",    10,   30,   30)
@@ -81,7 +81,8 @@ def build_cashflow_and_sheet(p):
     return brrrr_cf(p)
 
 def build_metrics(initial_equity, cf):
-    irr = nf.irr([-initial_equity] + cf)
+    monthly_irr = nf.irr([-initial_equity] + cf)
+    irr = (1 + monthly_irr) ** 12 - 1
     total_roi = sum(cf) / initial_equity if initial_equity else 0
     return irr, total_roi
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,12 @@
+import numpy_financial as nf
+import pytest
+from subject_to_analyzer import build_metrics
+
+
+def test_build_metrics_simple_case():
+    irr, roi = build_metrics(1000, [1100])
+    expected_monthly = nf.irr([-1000, 1100])
+    expected_annual = (1 + expected_monthly) ** 12 - 1
+    expected_roi = 1100 / 1000
+    assert irr == pytest.approx(expected_annual, rel=1e-6)
+    assert roi == pytest.approx(expected_roi, rel=1e-6)


### PR DESCRIPTION
## Summary
- fix stray text in `rent_growth` slider comment
- convert monthly IRR to annual rate in `build_metrics`
- document rent growth slider correctly
- add `altair` to dependencies
- add unit test for `build_metrics`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c9f5b9a00832b952388f045df3365